### PR TITLE
Use TSConfigJson from type-fest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "my-next-app",
+  "name": "tsconfig.guide",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "my-next-app",
+      "name": "tsconfig.guide",
       "version": "0.1.0",
       "dependencies": {
         "@headlessui/react": "^1.7.19",
@@ -27,7 +27,7 @@
         "autoprefixer": "^10.0.1",
         "postcss": "^8",
         "tailwindcss": "^3.3.0",
-        "types-tsconfig": "^2.0.2",
+        "type-fest": "^4.18.0",
         "typescript": "^5",
         "vercel": "^34.1.3",
         "wrangler": "^3.52.0"
@@ -6001,28 +6001,15 @@
       "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA=="
     },
     "node_modules/type-fest": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.0.tgz",
+      "integrity": "sha512-+dbmiyliDY/2TTcjCS7NpI9yV2iEFlUDk5TKnsbkN7ZoRu5s7bT+zvYtNFhFXC2oLwURGT2frACAZvbbyNBI+w==",
       "dev": true,
       "engines": {
-        "node": ">=14.16"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/types-tsconfig": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/types-tsconfig/-/types-tsconfig-2.0.2.tgz",
-      "integrity": "sha512-La7awO5Ge1y9Ew/puVOtm7uZW9hLAGCTSY1F/7guQ7t6oaOvPmeKOcfdVVctjeVj+5S2J6esH8qwVW0eI7rQyQ==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^3.5.1",
-        "zod": "^3.20.2"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "my-next-app",
+  "name": "tsconfig.guide",
   "version": "0.1.0",
-  "private": true,
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -32,7 +31,7 @@
     "autoprefixer": "^10.0.1",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
-    "types-tsconfig": "^2.0.2",
+    "type-fest": "^4.18.0",
     "typescript": "^5",
     "vercel": "^34.1.3",
     "wrangler": "^3.52.0"

--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -13,9 +13,7 @@ import {
 import { Highlight, themes } from "prism-react-renderer";
 import { useRef, useState } from "react";
 import Confetti from "react-confetti";
-import { TSConfigJSON } from "types-tsconfig";
-
-type EditorProps = {};
+import { TsConfigJson } from "type-fest";
 
 function writeCommentBeforeLine(
   parsedConfig: CommentJSONValue,
@@ -33,7 +31,7 @@ function writeCommentBeforeLine(
   ];
 }
 
-export default function Editor(props: EditorProps) {
+export default function Editor() {
   const editorRef = useRef<HTMLDivElement>(null);
 
   const [isExploding, setIsExploding] = useState(false);
@@ -49,7 +47,7 @@ export default function Editor(props: EditorProps) {
     },
   } = useOptions();
 
-  let config: TSConfigJSON = {
+  let config: TsConfigJson = {
     compilerOptions: {
       esModuleInterop: true,
       skipLibCheck: true,
@@ -84,7 +82,7 @@ export default function Editor(props: EditorProps) {
       ...config.compilerOptions,
       module: "preserve",
       noEmit: true,
-    } as any as TSConfigJSON["compilerOptions"]; // This TS types lib does not recognize preserve as a module type
+    };
   }
 
   if (tsTranspiling && buildingLib) {
@@ -107,12 +105,12 @@ export default function Editor(props: EditorProps) {
     config.compilerOptions = {
       ...config.compilerOptions,
       lib: ["es2022", "dom", "dom.iterable"],
-    } as any as TSConfigJSON["compilerOptions"]; // TS Types lib does not recognize es2022 as a lib type
+    };
   } else {
     config.compilerOptions = {
       ...config.compilerOptions,
       lib: ["es2022"],
-    } as any as TSConfigJSON["compilerOptions"]; // TS Types lib does not recognize es2022 as a lib type
+    };
   }
 
   let parsed = parse(JSON.stringify(config)) as CommentObject;


### PR DESCRIPTION
The PR to [add `preserve` module type and `es2022` libs to `type-fest`](https://github.com/sindresorhus/type-fest/pull/874) was approved and merged.

This PR updates the editor to use the exported `TSConfigJson` type for type checkin the parsed TS Config. 